### PR TITLE
Update Dockerfile: set root password and create user groups for impro…

### DIFF
--- a/3.2.1/Dockerfile
+++ b/3.2.1/Dockerfile
@@ -27,6 +27,9 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN echo "root:SagittariusA" | chpasswd
+
+# Create groups
 RUN groupadd -f gasgiants && \
     groupadd -f dwarfs && \
     groupadd -f icegiants && \


### PR DESCRIPTION
…ved management. Added a command to set the root password to 'SagittariusA' and created groups for gasgiants, dwarfs, and icegiants to enhance user organization and access control.