### PR TITLE
Fix Dockerfile: correct the executable name for supergiant_check in t…

### DIFF
--- a/3.2.1/Dockerfile
+++ b/3.2.1/Dockerfile
@@ -115,7 +115,7 @@ RUN gcc -o /var/ss/asteroid /var/ss/asteroid.c && \
     gcc -o /var/ss/singularity_check /var/ss/singularity_check.c && \
     gcc -o /var/ss/supergiant_check /var/ss/supergiant.c && \
     gcc -o /var/ss/final_check /var/ss/final_check.c && \
-    chmod +x /var/ss/asteroid /var/ss/meteor /var/ss/comet /var/ss/pulsar_check /var/ss/supernova /var/ss/blackhole /var/ss/neutronstar_check /var/ss/eventhorizon_check /var/ss/singularity_check /var/ss/supergiant /var/ss/final_check && \
+    chmod +x /var/ss/asteroid /var/ss/meteor /var/ss/comet /var/ss/pulsar_check /var/ss/supernova /var/ss/blackhole /var/ss/neutronstar_check /var/ss/eventhorizon_check /var/ss/singularity_check /var/ss/supergiant_check /var/ss/final_check && \
     rm -rf /var/ss/*.c
 
 # Create and set permissions for /var/ss/pulsar and other files


### PR DESCRIPTION
…he chmod command to ensure proper permissions are set for all relevant files in /var/ss, enhancing clarity and maintainability.